### PR TITLE
feat: Java 21 LTS migration with qbit-build-parent 1.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  qqq-orb: kingsrook/qqq-orb@0.3.6
+  qqq-orb: kingsrook/qqq-orb@0.5.0
 
 workflows:
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
    <parent>
       <groupId>com.kingsrook</groupId>
       <artifactId>qbit-build-parent</artifactId>
-      <version>1.5.0</version>
+      <version>1.5.1</version>
    </parent>
 
    <groupId>com.kingsrook.qbits</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
    <parent>
       <groupId>com.kingsrook</groupId>
       <artifactId>qbit-build-parent</artifactId>
-      <version>1.1.0</version>
+      <version>1.5.0</version>
    </parent>
 
    <groupId>com.kingsrook.qbits</groupId>
@@ -64,7 +64,7 @@
    </scm>
 
    <properties>
-      <revision>v0.2.1</revision>
+      <revision>0.3.0-SNAPSHOT</revision>
    </properties>
 
  <dependencyManagement>


### PR DESCRIPTION
Migrate to Java 21 with qbit-build-parent 1.5.0 and qqq-orb 0.5.0